### PR TITLE
Only include HAML and Slim component when using HAML or Slim

### DIFF
--- a/lib/angular-rails4-templates/engine.rb
+++ b/lib/angular-rails4-templates/engine.rb
@@ -34,8 +34,12 @@ module AngularRails4Templates
         env.register_mime_type 'text/ng-html', extensions: ['.nghtml']
         env.register_mime_type 'text/ng-haml', extensions: ['.nghaml']
         env.register_mime_type 'text/ng-slim', extensions: ['.ngslim']
-        env.register_transformer 'text/ng-slim', 'application/javascript', AngularRails4Templates::SlimProcessor
-        env.register_transformer 'text/ng-haml', 'application/javascript', AngularRails4Templates::HamlProcessor
+        if defined? Slim
+          env.register_transformer 'text/ng-slim', 'application/javascript', AngularRails4Templates::SlimProcessor
+        end
+        if defined? Haml
+          env.register_transformer 'text/ng-haml', 'application/javascript', AngularRails4Templates::HamlProcessor
+        end
         env.register_transformer 'text/ng-html', 'application/javascript', AngularRails4Templates::Processor
       end
 

--- a/lib/angular-rails4-templates/haml_processor.rb
+++ b/lib/angular-rails4-templates/haml_processor.rb
@@ -1,19 +1,19 @@
-require 'angular-rails4-templates/compact_javascript_escape'
-require 'haml'
+if defined? Haml
+  require 'angular-rails4-templates/compact_javascript_escape'
+  require 'haml'
 
-module AngularRails4Templates
-  class HamlProcessor < Processor
+  module AngularRails4Templates
+    class HamlProcessor < Processor
+      include CompactJavaScriptEscape
 
-    include CompactJavaScriptEscape
-
-    def render_html(input)
-      template = input[:data]
-      haml_engine = Haml::Engine.new(template)
-      output = haml_engine.render
-      escape_javascript output
-    rescue Haml::SyntaxError => ex
-      raise Haml::SyntaxError.new("#{input[:filename]} #{ex.message}", ex.line)
+      def render_html(input)
+        template = input[:data]
+        haml_engine = Haml::Engine.new(template)
+        output = haml_engine.render
+        escape_javascript output
+      rescue Haml::SyntaxError => ex
+        raise Haml::SyntaxError.new("#{input[:filename]} #{ex.message}", ex.line)
+      end
     end
-
   end
 end

--- a/lib/angular-rails4-templates/slim_processor.rb
+++ b/lib/angular-rails4-templates/slim_processor.rb
@@ -1,15 +1,17 @@
-require 'angular-rails4-templates/compact_javascript_escape'
-require 'slim'
+if defined? Slim
+  require 'angular-rails4-templates/compact_javascript_escape'
+  require 'slim'
 
-module AngularRails4Templates
-  class SlimProcessor < Processor
+  module AngularRails4Templates
+    class SlimProcessor < Processor
 
-    include CompactJavaScriptEscape
+      include CompactJavaScriptEscape
 
-    def render_html(input)
-      template = input[:data]
-      output = Slim::Template.new { template }.render
-      escape_javascript output
+      def render_html(input)
+        template = input[:data]
+        output = Slim::Template.new { template }.render
+        escape_javascript output
+      end
     end
   end
 end


### PR DESCRIPTION
This PR will removes Haml and Slim as requirements for including `angular-rails4-templates` in your Rails application.

Tested on Rails 4.1 and 4.2.

Previously, you would have to add the gems `haml` and `slim` to your Gemfile even if you didn't use them so your app would start.
